### PR TITLE
refactor(oop)!: Introduce a Golang-like API

### DIFF
--- a/examples/classify/main.go
+++ b/examples/classify/main.go
@@ -11,50 +11,75 @@ import (
 
 func main() {
 
-	if len(os.Args) < 2 {
-		fmt.Println("Usage: ./classify <filename>")
+	if len(os.Args) < 2 || len(os.Args) > 3 {
+		fmt.Printf("Usage: %s <filename> [model]\n", os.Args[0])
 		return
 	}
 
-	path := os.Args[1]
-
-	var session vaccel.Session
-
-	err := vaccel.SessionInit(&session, 0)
-
-	if err != 0 {
-		fmt.Println("error initializing session")
-		os.Exit(err)
-	}
-
-	var outText string
-
-	/* Run the Operation providing the path */
-	outText, err = vaccel.ImageClassificationFromFile(&session, path)
-
-	if err != 0 {
-		fmt.Println("Image Classification failed")
-		os.Exit(err)
-	}
-
-	fmt.Println("Output(1): ", outText)
-
-	imageBytes, e := os.ReadFile(path)
+	image := os.Args[1]
+	imageBytes, e := os.ReadFile(image)
 	if e != nil {
 		fmt.Printf("Error reading file: %s\n", e)
 		os.Exit(1)
 	}
 
-	outText, err = vaccel.ImageClassification(&session, imageBytes)
+	var outText string
+	var session vaccel.Session
+	var resource vaccel.Resource
 
-	if err != 0 {
-		fmt.Println("Image Classification failed")
+	err := session.Init(0)
+	if err != vaccel.OK {
+		fmt.Println("error initializing session")
 		os.Exit(err)
 	}
 
+	if len(os.Args) == 3 {
+		model := os.Args[2]
+		err = resource.Init(model, vaccel.ResourceModel)
+		if err != vaccel.OK {
+			fmt.Printf("error initializing resource: %d\n", err)
+			goto ReleaseSession
+		}
+
+		err = session.Register(&resource)
+		if err != vaccel.OK {
+			fmt.Printf("error while registering resource: %d\n", err)
+			goto ReleaseResource
+		}
+	}
+
+	outText, err = vaccel.ImageClassificationFromFile(&session, image)
+	if err != vaccel.OK {
+		fmt.Println("Image Classification failed")
+		goto UnregisterResource
+	}
+	fmt.Println("Output(1): ", outText)
+
+	outText, err = vaccel.ImageClassification(&session, imageBytes)
+	if err != vaccel.OK {
+		fmt.Println("Image Classification failed")
+		goto UnregisterResource
+	}
 	fmt.Println("Output(2): ", outText)
 
-	if vaccel.SessionRelease(&session) != 0 {
+UnregisterResource:
+	if len(os.Args) == 3 {
+		err = session.Unregister(&resource)
+		if err != vaccel.OK {
+			fmt.Printf("Could not unregister resource: %d\n", err)
+		}
+	}
+ReleaseResource:
+	if len(os.Args) == 3 {
+		err = resource.Release()
+		if err != vaccel.OK {
+			fmt.Printf("Could not release resource: %d\n", err)
+		}
+	}
+ReleaseSession:
+	err = session.Release()
+	if err != vaccel.OK {
 		fmt.Println("An error occurred while freeing the session")
+		os.Exit(1)
 	}
 }

--- a/examples/exec/main.go
+++ b/examples/exec/main.go
@@ -29,22 +29,21 @@ func main() {
 	}
 
 	var session vaccel.Session
-	err := vaccel.SessionInit(&session, 0)
-	if err != 0 {
+	err := session.Init(0)
+	if err != vaccel.OK {
 		fmt.Println("error initializing session")
 		os.Exit(int(err))
 	}
 
 	var res vaccel.Resource
-	err = vaccel.ResourceInit(&res, path, vaccel.ResourceLib)
-
-	if err != 0 {
+	err = res.Init(path, vaccel.ResourceLib)
+	if err != vaccel.OK {
 		fmt.Println("error creating shared object resource")
 		os.Exit(int(err))
 	}
 
-	err = vaccel.ResourceRegister(&res, &session)
-	if err != 0 {
+	err = session.Register(&res)
+	if err != vaccel.OK {
 		fmt.Println("error registering resource with session")
 		os.Exit(int(err))
 	}
@@ -60,7 +59,7 @@ func main() {
 	buf := unsafe.Pointer(&inputInt)
 	size := unsafe.Sizeof(inputInt)
 
-	if read.AddSerialArg(buf, size) != 0 {
+	if read.AddSerialArg(buf, size) != vaccel.OK {
 		fmt.Println("Error Adding Serialized arg")
 		os.Exit(0)
 	}
@@ -69,14 +68,13 @@ func main() {
 	buf = unsafe.Pointer(&output)
 	size = unsafe.Sizeof(output)
 
-	if write.ExpectSerialArg(buf, size) != 0 {
+	if write.ExpectSerialArg(buf, size) != vaccel.OK {
 		fmt.Println("Error defining expected arg")
 		os.Exit(0)
 	}
 
 	err = vaccel.ExecWithResource(&session, &res, "mytestfunc", read, write)
-
-	if err != 0 {
+	if err != vaccel.OK {
 		fmt.Println("An error occurred while running the operation")
 		os.Exit(err)
 	}
@@ -97,20 +95,20 @@ func main() {
 	val = C.uint(*cast)
 	fmt.Println("Output(3): ", val)
 
-	if write.Delete() != 0 || read.Delete() != 0 {
+	if write.Delete() != vaccel.OK || read.Delete() != vaccel.OK {
 		fmt.Println("An error occurred in deletion of the arg-lists")
 		os.Exit(0)
 	}
 
-	if vaccel.ResourceUnregister(&res, &session) != 0 {
+	if session.Unregister(&res) != vaccel.OK {
 		fmt.Println("An error occurred while unregistering the resource")
 	}
 
-	if vaccel.ResourceRelease(&res) != 0 {
+	if res.Release() != vaccel.OK {
 		fmt.Println("An error occurred while releasing the resource")
 	}
 
-	if vaccel.SessionRelease(&session) != 0 {
+	if session.Release() != vaccel.OK {
 		fmt.Println("An error occurred while releasing the session")
 	}
 }

--- a/examples/noop/main.go
+++ b/examples/noop/main.go
@@ -10,27 +10,24 @@ import (
 )
 
 func main() {
-
-	/* Session */
 	var session vaccel.Session
-	err := vaccel.SessionInit(&session, 0)
 
-	if err != 0 {
+	err := session.Init(0)
+	if err != vaccel.OK {
 		fmt.Println("error initializing session")
 		os.Exit(int(err))
 	}
 
-	/* Run the operation */
 	err = vaccel.NoOp(&session)
-
-	if err != 0 {
+	if err != vaccel.OK {
 		fmt.Println("An error occurred while running the operation")
 		os.Exit(err)
 	}
 
-	/* Free Session */
-	if vaccel.SessionRelease(&session) != 0 {
+	err = session.Release()
+	if err != vaccel.OK {
 		fmt.Println("An error occurred while freeing the session")
+		os.Exit(err)
 	}
 
 }

--- a/vaccel/resource.go
+++ b/vaccel/resource.go
@@ -26,18 +26,10 @@ func (t ResourceType) ToCEnum() C.vaccel_resource_type_t {
 	return C.vaccel_resource_type_t(t)
 }
 
-func ResourceInit(res *Resource, path string, resType ResourceType) int {
-	return int(C.vaccel_resource_init(&res.cRes, C.CString(path), resType.ToCEnum())) //nolint:gocritic
+func (r *Resource) Init(path string, resType ResourceType) int {
+	return int(C.vaccel_resource_init(&r.cRes, C.CString(path), resType.ToCEnum())) //nolint:gocritic
 }
 
-func ResourceRegister(res *Resource, sess *Session) int {
-	return int(C.vaccel_resource_register(&res.cRes, &sess.cSess)) //nolint:gocritic
-}
-
-func ResourceUnregister(res *Resource, sess *Session) int {
-	return int(C.vaccel_resource_unregister(&res.cRes, &sess.cSess)) //nolint:gocritic
-}
-
-func ResourceRelease(res *Resource) int {
-	return int(C.vaccel_resource_release(&res.cRes)) //nolint:gocritic
+func (r *Resource) Release() int {
+	return int(C.vaccel_resource_release(&r.cRes)) //nolint:gocritic
 }

--- a/vaccel/session.go
+++ b/vaccel/session.go
@@ -14,10 +14,18 @@ type Session struct {
 	cSess C.struct_vaccel_session
 }
 
-func SessionInit(sess *Session, flags uint32) int {
-	return int(C.vaccel_session_init(&sess.cSess, C.uint32_t(flags))) //nolint:gocritic
+func (s *Session) Init(flags uint32) int {
+	return int(C.vaccel_session_init(&s.cSess, C.uint32_t(flags))) //nolint:gocritic
 }
 
-func SessionRelease(sess *Session) int {
-	return int(C.vaccel_session_release(&sess.cSess)) //nolint:gocritic
+func (s *Session) Release() int {
+	return int(C.vaccel_session_release(&s.cSess)) //nolint:gocritic
+}
+
+func (s *Session) Register(r *Resource) int {
+	return int(C.vaccel_resource_register(&r.cRes, &s.cSess)) //nolint:gocritic
+}
+
+func (s *Session) Unregister(r *Resource) int {
+	return int(C.vaccel_resource_unregister(&r.cRes, &s.cSess)) //nolint:gocritic
 }

--- a/vaccel/tf.go
+++ b/vaccel/tf.go
@@ -51,51 +51,51 @@ type TFBuffer struct {
 	cTFBuf C.struct_vaccel_tf_buffer
 }
 
-func BufferInit(buffer *TFBuffer, data uintptr, size uint) int {
+func (b *TFBuffer) Init(data uintptr, size uint) int {
 	cData := unsafe.Pointer(data)
 	cSize := C.size_t(size)
-	return int(C.vaccel_tf_buffer_init(&buffer.cTFBuf, cData, cSize)) //nolint:gocritic
+	return int(C.vaccel_tf_buffer_init(&b.cTFBuf, cData, cSize)) //nolint:gocritic
 }
 
-func TFBufferRelease(buffer *TFBuffer) int {
-	return int(C.vaccel_tf_buffer_release(&buffer.cTFBuf)) //nolint:gocritic
+func (b *TFBuffer) Release() int {
+	return int(C.vaccel_tf_buffer_release(&b.cTFBuf)) //nolint:gocritic
 }
 
-func TFBufferTakeData(buffer *TFBuffer, outData *uintptr, outSize *uint) int {
-	if buffer == nil || outData == nil || outSize == nil {
-		return EINVAL
+func (b *TFBuffer) TakeData() (uintptr, uint) {
+	if b == nil {
+		return 0, 0
 	}
 
-	*outData = uintptr(buffer.cTFBuf.data)
-	*outSize = uint(buffer.cTFBuf.size)
+	outData := uintptr(b.cTFBuf.data)
+	outSize := uint(b.cTFBuf.size)
 
-	buffer.cTFBuf.data = nil
-	buffer.cTFBuf.size = 0
+	b.cTFBuf.data = nil
+	b.cTFBuf.size = 0
 
-	return OK
+	return outData, outSize
 }
 
 type TFNode struct {
 	cTFNode C.struct_vaccel_tf_node
 }
 
-func TFNodeInit(node *TFNode, name string, id int) int {
+func (n *TFNode) Init(name string, id int) int {
 	cInt := C.int(id)
 	cStr := C.CString(name)
 	defer C.free(unsafe.Pointer(cStr))
-	return int(C.vaccel_tf_node_init(&node.cTFNode, cStr, cInt)) //nolint:gocritic
+	return int(C.vaccel_tf_node_init(&n.cTFNode, cStr, cInt)) //nolint:gocritic
 }
 
-func TFNodeRelease(node *TFNode) int {
-	return int(C.vaccel_tf_node_release(&node.cTFNode)) //nolint:gocritic
+func (n *TFNode) Release() int {
+	return int(C.vaccel_tf_node_release(&n.cTFNode)) //nolint:gocritic
 }
 
 type TFTensor struct {
 	cTFTensor C.struct_vaccel_tf_tensor
 }
 
-func TFTensorInit(tensor *TFTensor, dims []int64, dtype TFDataType) int {
-	if tensor == nil || len(dims) == 0 {
+func (t *TFTensor) Init(dims []int64, dtype TFDataType) int {
+	if t == nil || len(dims) == 0 {
 		return EINVAL
 	}
 
@@ -111,7 +111,7 @@ func TFTensorInit(tensor *TFTensor, dims []int64, dtype TFDataType) int {
 	}
 
 	ret := C.vaccel_tf_tensor_init(
-		&tensor.cTFTensor,
+		&t.cTFTensor,
 		C.int(len(dims)),
 		cDims,
 		C.enum_vaccel_tf_data_type(dtype), //nolint:gocritic
@@ -120,12 +120,12 @@ func TFTensorInit(tensor *TFTensor, dims []int64, dtype TFDataType) int {
 	return int(ret)
 }
 
-func TFTensorRelease(tensor *TFTensor) int {
-	return int(C.vaccel_tf_tensor_release(&tensor.cTFTensor)) //nolint:gocritic
+func (t *TFTensor) Release() int {
+	return int(C.vaccel_tf_tensor_release(&t.cTFTensor)) //nolint:gocritic
 }
 
-func TFTensorAllocate(tensor *TFTensor, dims []int64, dtype TFDataType, totalSize uint) int {
-	ret := TFTensorInit(tensor, dims, dtype)
+func (t *TFTensor) Allocate(dims []int64, dtype TFDataType, totalSize uint) int {
+	ret := t.Init(dims, dtype)
 	if ret != OK {
 		return ret
 	}
@@ -134,47 +134,47 @@ func TFTensorAllocate(tensor *TFTensor, dims []int64, dtype TFDataType, totalSiz
 		return OK
 	}
 
-	tensor.cTFTensor.data = C.malloc(C.size_t(totalSize))
-	if tensor.cTFTensor.data == nil {
-		C.vaccel_tf_tensor_release(&tensor.cTFTensor) //nolint:gocritic
+	t.cTFTensor.data = C.malloc(C.size_t(totalSize))
+	if t.cTFTensor.data == nil {
+		C.vaccel_tf_tensor_release(&t.cTFTensor) //nolint:gocritic
 		return ENOMEM
 	}
 
-	tensor.cTFTensor.size = C.size_t(totalSize)
-	tensor.cTFTensor.owned = true
+	t.cTFTensor.size = C.size_t(totalSize)
+	t.cTFTensor.owned = true
 
 	return OK
 }
 
-func TFTensorSetData(tensor *TFTensor, data uintptr, size uint, own bool) int {
-	if tensor == nil {
+func (t *TFTensor) SetData(data uintptr, size uint, own bool) int {
+	if t == nil {
 		return EINVAL
 	}
 
-	if tensor.cTFTensor.data != nil && tensor.cTFTensor.owned {
+	if t.cTFTensor.data != nil && t.cTFTensor.owned {
 		fmt.Println("Previous tensor data will not be freed by release!")
 	}
 
-	tensor.cTFTensor.data = unsafe.Pointer(data)
-	tensor.cTFTensor.size = C.size_t(size)
-	tensor.cTFTensor.owned = C.bool(own)
+	t.cTFTensor.data = unsafe.Pointer(data)
+	t.cTFTensor.size = C.size_t(size)
+	t.cTFTensor.owned = C.bool(own)
 
 	return OK
 }
 
-func TFTensorTakeData(tensor *TFTensor, outData *uintptr, outSize *uint) int {
-	if tensor == nil || outData == nil || outSize == nil {
-		return EINVAL
+func (t *TFTensor) TakeData() (uintptr, uint) {
+	if t == nil {
+		return 0, 0
 	}
 
-	*outData = uintptr(tensor.cTFTensor.data)
-	*outSize = uint(tensor.cTFTensor.size)
+	outData := uintptr(t.cTFTensor.data)
+	outSize := uint(t.cTFTensor.size)
 
-	tensor.cTFTensor.data = nil
-	tensor.cTFTensor.size = 0
-	tensor.cTFTensor.owned = false
+	t.cTFTensor.data = nil
+	t.cTFTensor.size = 0
+	t.cTFTensor.owned = false
 
-	return OK
+	return outData, outSize
 }
 
 func (t *TFTensor) Data() uintptr {
@@ -191,11 +191,11 @@ func (t *TFTensor) NrDims() int {
 	return int(t.cTFTensor.nr_dims)
 }
 
-func (t *TFTensor) Type() int {
+func (t *TFTensor) Type() TFDataType {
 	if t == nil || t.cTFTensor.data_type < 1 {
 		return -1
 	}
-	return int(t.cTFTensor.data_type)
+	return TFDataType(t.cTFTensor.data_type)
 }
 
 func (t *TFTensor) Dims() []int64 {
@@ -281,32 +281,44 @@ type TFStatus struct {
 	cTFStatus C.struct_vaccel_tf_status
 }
 
-func TFStatusInit(status *TFStatus, errorCode uint8, message string) int {
-	if status == nil {
-		return EINVAL
-	}
-
+func (s *TFStatus) Init(errorCode uint8, message string) int {
+	cErr := C.uint8_t(errorCode)
 	cMsg := C.CString(message)
 	defer C.free(unsafe.Pointer(cMsg))
-
-	ret := C.vaccel_tf_status_init(&status.cTFStatus, C.uint8_t(errorCode), cMsg) //nolint:gocritic
-	return int(ret)
+	return int(C.vaccel_tf_status_init(&s.cTFStatus, cErr, cMsg)) //nolint:gocritic
 }
 
-func TFStatusRelease(status *TFStatus) int {
-	if status == nil {
+func (s *TFStatus) Release() int {
+	if s == nil {
 		return EINVAL
 	}
-	return int(C.vaccel_tf_status_release(&status.cTFStatus)) //nolint:gocritic
+	return int(C.vaccel_tf_status_release(&s.cTFStatus)) //nolint:gocritic
 }
 
-func TFSessionLoad(sess *Session, model *Resource, status *TFStatus) int {
-	return int(C.vaccel_tf_session_load(&sess.cSess, &model.cRes, &status.cTFStatus)) //nolint:gocritic
+type TFSession struct {
+	Sess  *Session
+	Model *Resource
 }
 
-func TFSessionRun(
-	sess *Session,
-	model *Resource,
+func (tfs *TFSession) Init(sess *Session, model *Resource) int {
+	if sess == nil || model == nil {
+		return EINVAL
+	}
+
+	tfs.Sess = sess
+	tfs.Model = model
+
+	return OK
+}
+
+func (tfs *TFSession) Load(status *TFStatus) int {
+	if tfs == nil || tfs.Sess == nil || tfs.Model == nil {
+		return EINVAL
+	}
+	return int(C.vaccel_tf_session_load(&tfs.Sess.cSess, &tfs.Model.cRes, &status.cTFStatus)) //nolint:gocritic
+}
+
+func (tfs *TFSession) Run(
 	runOptions *TFBuffer,
 	inNodes *TFNode,
 	inTensors []TFTensor,
@@ -314,7 +326,7 @@ func TFSessionRun(
 	outTensors *[]TFTensor,
 	status *TFStatus,
 ) int {
-	if sess == nil || model == nil || inNodes == nil || outNodes == nil || status == nil || outTensors == nil {
+	if tfs == nil || tfs.Sess == nil || tfs.Model == nil || inNodes == nil || outNodes == nil || status == nil || outTensors == nil {
 		return EINVAL
 	}
 
@@ -338,8 +350,8 @@ func TFSessionRun(
 	defer C.free(cOutPtr)
 
 	ret := int(C.vaccel_tf_session_run(
-		&sess.cSess,
-		&model.cRes,
+		&tfs.Sess.cSess,
+		&tfs.Model.cRes,
 		func() *C.struct_vaccel_tf_buffer {
 			if runOptions != nil {
 				return &runOptions.cTFBuf
@@ -368,7 +380,7 @@ func TFSessionRun(
 			src := unsafe.Slice((*int64)(unsafe.Pointer(outTensorSlice[i].dims)), nrDims)
 			copy(dims, src)
 
-			ret = TFTensorInit(&(*outTensors)[i], dims, dtype)
+			ret = (*outTensors)[i].Init(dims, dtype)
 			if ret != OK {
 				fmt.Println("Could not initialize output tensor from C dims and type")
 				return ret
@@ -391,7 +403,7 @@ func TFSessionRun(
 			goData := uintptr(data)
 			goSize := uint(size)
 
-			ret = TFTensorSetData(&(*outTensors)[i], goData, goSize, true)
+			ret = (*outTensors)[i].SetData(goData, goSize, true)
 			if ret != OK {
 				fmt.Println("Could not set data for Golang output tensor")
 				return ret
@@ -402,6 +414,11 @@ func TFSessionRun(
 	return OK
 }
 
-func TFSessionDelete(sess *Session, model *Resource, status *TFStatus) int {
-	return int(C.vaccel_tf_session_delete(&sess.cSess, &model.cRes, &status.cTFStatus)) //nolint:gocritic
+func (tfs *TFSession) Delete(status *TFStatus) int {
+	err := int(C.vaccel_tf_session_delete(&tfs.Sess.cSess, &tfs.Model.cRes, &status.cTFStatus)) //nolint:gocritic
+	if err == OK {
+		tfs.Sess = nil
+		tfs.Model = nil
+	}
+	return err
 }


### PR DESCRIPTION
- chore: Update examples based on OOP changes

Follow up:
 - Use pointers to heap allocated C vAccel structures, instead of storing them
   in the stack as a `struct` attribute
 - Use Golang native cleanup tools - https://go.dev/blog/cleanups-and-weak
 - Return paired (object | error) on vAccel package functions