### PR TITLE
fix(session): Fix CGO pointer rules

### DIFF
--- a/vaccel/exec.go
+++ b/vaccel/exec.go
@@ -20,7 +20,7 @@ func ExecWithResource(sess *Session, res *Resource, funcname string,
 	cNrRead := C.size_t(read.cList.size)
 	cNrWrite := C.size_t(write.cList.size)
 
-	cRet := C.vaccel_exec_with_resource(&sess.cSess, res.cRes, cfunc, cread, cNrRead, cwrite, cNrWrite) //nolint:gocritic
+	cRet := C.vaccel_exec_with_resource(sess.cSess, res.cRes, cfunc, cread, cNrRead, cwrite, cNrWrite) //nolint:gocritic
 
 	return int(cRet)
 

--- a/vaccel/genop.go
+++ b/vaccel/genop.go
@@ -18,7 +18,7 @@ func Genop(sess *Session, read *ArgList, write *ArgList) int {
 	cNrRead := C.int(read.cList.size)
 	cNrWrite := C.int(write.cList.size)
 
-	cRet := C.vaccel_genop(&sess.cSess, cRead, cNrRead, cWrite, cNrWrite) //nolint:gocritic
+	cRet := C.vaccel_genop(sess.cSess, cRead, cNrRead, cWrite, cNrWrite) //nolint:gocritic
 	return int(cRet)
 
 }

--- a/vaccel/image_classification.go
+++ b/vaccel/image_classification.go
@@ -35,7 +35,7 @@ func ImageClassificationFromFile(sess *Session, imagePath string) (string, int) 
 	defer C.free(unsafe.Pointer(cOutImageName))
 
 	cRet := C.vaccel_image_classification(
-		&sess.cSess, cImgBuf, cText, cOutImageName,
+		sess.cSess, cImgBuf, cText, cOutImageName,
 		cImgLen, C.size_t(256), C.size_t(256)) //nolint:gocritic
 
 	var golangOut string
@@ -66,7 +66,7 @@ func ImageClassification(sess *Session, image []byte) (string, int) {
 	defer C.free(unsafe.Pointer(cOutImageName))
 
 	cRet := C.vaccel_image_classification(
-		&sess.cSess, cImgBuf, cText, cOutImageName,
+		sess.cSess, cImgBuf, cText, cOutImageName,
 		cImgLen, C.size_t(256), C.size_t(256)) //nolint:gocritic
 
 	var golangOut string

--- a/vaccel/noop.go
+++ b/vaccel/noop.go
@@ -11,5 +11,5 @@ package vaccel
 import "C"
 
 func NoOp(sess *Session) int {
-	return int(C.vaccel_noop(&sess.cSess)) //nolint:gocritic
+	return int(C.vaccel_noop(sess.cSess)) //nolint:gocritic
 }

--- a/vaccel/session.go
+++ b/vaccel/session.go
@@ -11,23 +11,23 @@ package vaccel
 import "C"
 
 type Session struct {
-	cSess C.struct_vaccel_session
+	cSess *C.struct_vaccel_session
 }
 
 func (s *Session) Init(flags uint32) int {
-	return int(C.vaccel_session_init(&s.cSess, C.uint32_t(flags))) //nolint:gocritic
+	return int(C.vaccel_session_new(&s.cSess, C.uint32_t(flags))) //nolint:gocritic
 }
 
 func (s *Session) Release() int {
-	return int(C.vaccel_session_release(&s.cSess)) //nolint:gocritic
+	return int(C.vaccel_session_delete(s.cSess)) //nolint:gocritic
 }
 
 func (s *Session) Register(r *Resource) int {
-	return int(C.vaccel_resource_register(r.cRes, &s.cSess)) //nolint:gocritic
+	return int(C.vaccel_resource_register(r.cRes, s.cSess)) //nolint:gocritic
 }
 
 func (s *Session) Unregister(r *Resource) int {
-	return int(C.vaccel_resource_unregister(r.cRes, &s.cSess)) //nolint:gocritic
+	return int(C.vaccel_resource_unregister(r.cRes, s.cSess)) //nolint:gocritic
 }
 
 func (s *Session) GetID() int64 {
@@ -35,7 +35,7 @@ func (s *Session) GetID() int64 {
 }
 
 func (s *Session) Update(flags uint32) int {
-	return int(C.vaccel_session_update(&s.cSess, C.uint32_t(flags))) //nolint:gocritic
+	return int(C.vaccel_session_update(s.cSess, C.uint32_t(flags))) //nolint:gocritic
 }
 
 func (s *Session) GetFlags() int32 {

--- a/vaccel/tf.go
+++ b/vaccel/tf.go
@@ -300,7 +300,7 @@ func TFModelLoad(sess *Session, model *Resource, status *TFStatus) int {
 		return EINVAL
 	}
 
-	return int(C.vaccel_tf_model_load(&sess.cSess, model.cRes, &status.cTFStatus)) //nolint:gocritic
+	return int(C.vaccel_tf_model_load(sess.cSess, model.cRes, &status.cTFStatus)) //nolint:gocritic
 }
 
 func TFModelRun(
@@ -337,7 +337,7 @@ func TFModelRun(
 	defer C.free(cOutPtr)
 
 	ret := int(C.vaccel_tf_model_run(
-		&sess.cSess,
+		sess.cSess,
 		model.cRes,
 		func() *C.struct_vaccel_tf_buffer {
 			if runOptions != nil {
@@ -402,6 +402,6 @@ func TFModelRun(
 }
 
 func TFModelUnload(sess *Session, model *Resource, status *TFStatus) int {
-	err := int(C.vaccel_tf_model_unload(&sess.cSess, model.cRes, &status.cTFStatus)) //nolint:gocritic
+	err := int(C.vaccel_tf_model_unload(sess.cSess, model.cRes, &status.cTFStatus)) //nolint:gocritic
 	return err
 }

--- a/vaccel/tflite.go
+++ b/vaccel/tflite.go
@@ -230,7 +230,7 @@ func TFLiteModelLoad(sess *Session, model *Resource) int {
 		return EINVAL
 	}
 
-	return int(C.vaccel_tflite_model_load(&sess.cSess, model.cRes)) //nolint:gocritic
+	return int(C.vaccel_tflite_model_load(sess.cSess, model.cRes)) //nolint:gocritic
 }
 
 func TFLiteModelRun(
@@ -264,7 +264,7 @@ func TFLiteModelRun(
 
 	var cStatus C.uint8_t
 	ret := int(C.vaccel_tflite_model_run(
-		&sess.cSess,
+		sess.cSess,
 		model.cRes,
 		(**C.struct_vaccel_tflite_tensor)(cInPtr),
 		C.int(nrInputs),
@@ -321,6 +321,6 @@ func TFLiteModelRun(
 }
 
 func TFLiteModelUnload(sess *Session, model *Resource) int {
-	err := int(C.vaccel_tflite_model_unload(&sess.cSess, model.cRes)) //nolint:gocritic
+	err := int(C.vaccel_tflite_model_unload(sess.cSess, model.cRes)) //nolint:gocritic
 	return err
 }

--- a/vaccel/torch.go
+++ b/vaccel/torch.go
@@ -190,7 +190,7 @@ func TorchModelLoad(sess *Session, model *Resource) int {
 		return EINVAL
 	}
 
-	return int(C.vaccel_torch_model_load(&sess.cSess, model.cRes)) //nolint:gocritic
+	return int(C.vaccel_torch_model_load(sess.cSess, model.cRes)) //nolint:gocritic
 }
 
 func TorchModelRun(
@@ -231,7 +231,7 @@ func TorchModelRun(
 	}
 
 	ret := int(C.vaccel_torch_model_run(
-		&sess.cSess,
+		sess.cSess,
 		model.cRes,
 		bufPtr,
 		(**C.struct_vaccel_torch_tensor)(cInPtr),


### PR DESCRIPTION
It seems that Go needs to keep track of memory allocated by itself. However, when this gets mixed with memory allocated from external functions (eg C), things get complicated. In order to avoid these issues, we define all internal structs as pointers to C structures instead of allocated C structure in Go.